### PR TITLE
Add initial Restaurant Tinder scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# Resturant-Tinder
+# Restaurant Tinder
+
+A simple prototype for a group-based restaurant selection app inspired by Tinder-style swiping. Users can create sessions with friends, swipe through restaurant options, and match on where to eat.
+
+## Features
+
+- **Group Sessions**: Invite friends to swipe together. Everyone in the session must swipe on each restaurant.
+- **Location Search**: Users set a location and distance radius. The backend queries Google Places for restaurants within this radius.
+- **Top Rated**: For each cuisine or food genre, only the top three restaurants (based on Google ratings) are returned.
+- **Swipe to Match**: When all participants swipe "like" on the same restaurant, everyone is notified of the match.
+- **Friends List**: Add friends so you can quickly create new swiping sessions.
+
+## Project Structure
+
+```
+server/   # Node.js + Express backend
+client/   # Front‑end app (React or React Native)
+```
+
+### Backend (`server`)
+
+The server exposes an API endpoint `/restaurants` that accepts query parameters for latitude, longitude, radius, and cuisine type. It uses the Google Places API to fetch restaurants and returns the three with the highest ratings.
+
+### Front‑end (`client`)
+
+A minimal front‑end will display restaurants as cards and allow swiping left/right. When a match occurs, all users see the selected restaurant.
+
+## Getting Started
+
+1. Install dependencies for the server:
+   ```bash
+   cd server
+   npm install
+   ```
+2. Create a `.env` file in `server/` with your Google Places API key:
+   ```
+   GOOGLE_PLACES_KEY=your_api_key_here
+   ```
+3. Start the server:
+   ```bash
+   node index.js
+   ```
+4. The front‑end can be implemented with your choice of framework (React, React Native, etc.).
+
+This is a minimal starting point. Feel free to extend it with user accounts, persistent storage, and real‑time updates.

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,9 @@
+# Client
+
+Front-end placeholder for the swiping interface. You can implement it with React, React Native, or another framework of your choice.
+
+Key components to build:
+- User authentication and friend list management
+- Session creation to invite friends
+- Swipe cards displaying restaurant info from the backend
+- Notification when all users match on the same restaurant

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,11 @@
+# Server
+
+Simple Express server that queries Google Places to return top three restaurants for a given cuisine and radius.
+
+## Usage
+
+1. Install dependencies with `npm install`.
+2. Create a `.env` file containing your `GOOGLE_PLACES_KEY`.
+3. Start the server using `node index.js`.
+
+The API endpoint `/restaurants` expects `lat`, `lng`, `radius`, and optional `cuisine` query parameters.

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,41 @@
+import express from 'express';
+import axios from 'axios';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const GOOGLE_KEY = process.env.GOOGLE_PLACES_KEY;
+
+// Basic endpoint to fetch top 3 restaurants for a cuisine within radius
+app.get('/restaurants', async (req, res) => {
+  const { lat, lng, radius = 5000, cuisine = '' } = req.query;
+  if (!GOOGLE_KEY || !lat || !lng) {
+    return res.status(400).json({ error: 'Missing parameters or API key' });
+  }
+
+  try {
+    const url = 'https://maps.googleapis.com/maps/api/place/nearbysearch/json';
+    const params = {
+      key: GOOGLE_KEY,
+      location: `${lat},${lng}`,
+      radius,
+      type: 'restaurant',
+      keyword: cuisine
+    };
+    const { data } = await axios.get(url, { params });
+    const sorted = (data.results || [])
+      .filter(r => r.rating)
+      .sort((a, b) => b.rating - a.rating)
+      .slice(0, 3);
+
+    res.json(sorted);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch places' });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "restaurant-tinder-server",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module",
+  "dependencies": {
+    "axios": "^1.6.0",
+    "dotenv": "^16.0.0",
+    "express": "^4.18.0"
+  }
+}


### PR DESCRIPTION
## Summary
- outline project goals and setup in README
- add server skeleton with Express endpoint for top 3 restaurants via Google Places
- include client placeholder and docs

## Testing
- `npm --version` (fails due to missing packages while checking environment)
- `npm install --package-lock-only` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841e379b30c8320801144336ff34b1c