### PR TITLE
Add basic client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-# Resturant-Tinder
+# Restaurant Tinder
+
+A simple prototype for a group-based restaurant selection app inspired by Tinder-style swiping. Users can create sessions with friends, swipe through restaurant options, and match on where to eat.
+
+## Features
+
+- **Group Sessions**: Invite friends to swipe together. Everyone in the session must swipe on each restaurant.
+- **Location Search**: Users set a location and distance radius. The backend queries Google Places for restaurants within this radius.
+- **Top Rated**: For each cuisine or food genre, only the top three restaurants (based on Google ratings) are returned.
+- **Swipe to Match**: When all participants swipe "like" on the same restaurant, everyone is notified of the match.
+- **Friends List**: Add friends so you can quickly create new swiping sessions.
+- **Sessions API**: Backend endpoints to manage friends and create swiping sessions.
+
+## Project Structure
+
+```
+server/   # Node.js + Express backend
+client/   # Front‑end app (React or React Native)
+```
+
+### Backend (`server`)
+
+The server exposes an API endpoint `/restaurants` that accepts query parameters for latitude, longitude, radius, and cuisine type. It uses the Google Places API to fetch restaurants and returns the three with the highest ratings.
+
+### Front‑end (`client`)
+
+A lightweight HTML/JavaScript interface is included in `client/index.html`. It fetches restaurants from the server and lets you like or skip each option.
+Open the file in a browser after starting the server to try it out.
+
+## Getting Started
+
+1. Install dependencies for the server:
+   ```bash
+   cd server
+   npm install
+   ```
+2. Create a `.env` file in `server/` with your Google Places API key:
+   ```
+   GOOGLE_PLACES_KEY=your_api_key_here
+   ```
+3. Start the server:
+   ```bash
+   node index.js
+   ```
+4. The front‑end can be implemented with your choice of framework (React, React Native, etc.).
+
+### API Overview
+
+- `GET /restaurants` - Fetch top restaurants for a location.
+- `POST /friends/add` - Add two users as friends.
+- `GET /friends/:userId` - Get a user's friends.
+- `POST /sessions` - Start a session and retrieve restaurants.
+- `POST /sessions/:id/swipe` - Submit a swipe; returns a match flag when all participants like the same place.
+
+This is a minimal starting point. Feel free to extend it with user accounts, persistent storage, and real‑time updates.

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,8 @@
+# Client
+
+Small vanilla JS demo for swiping through restaurants. Open `index.html` in a browser after the server is running.
+
+Possible enhancements:
+- Proper authentication and friend list management
+- Persistent sessions so swipes are saved
+- Real Tinder-style card animations

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Restaurant Tinder</title>
+  <style>
+    body { font-family: sans-serif; text-align: center; }
+    #card { border: 1px solid #ccc; padding: 20px; margin: auto; width: 300px; min-height: 120px; }
+    button { margin: 10px; }
+  </style>
+</head>
+<body>
+  <h1>Restaurant Tinder</h1>
+  <div id="card">Loading...</div>
+  <div>
+    <button id="like">Like</button>
+    <button id="skip">Skip</button>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/client/script.js
+++ b/client/script.js
@@ -1,0 +1,41 @@
+let restaurants = [];
+let current = 0;
+
+async function loadRestaurants() {
+  const params = new URLSearchParams({
+    lat: 40.730610, // example coordinates (NYC)
+    lng: -73.935242,
+    radius: 5000
+  });
+  try {
+    const res = await fetch(`/restaurants?${params}`);
+    if (!res.ok) throw new Error('request failed');
+    restaurants = await res.json();
+    current = 0;
+    showRestaurant();
+  } catch (err) {
+    document.getElementById('card').textContent = 'Failed to load restaurants';
+  }
+}
+
+function showRestaurant() {
+  const card = document.getElementById('card');
+  if (current >= restaurants.length) {
+    card.textContent = 'No more restaurants';
+    return;
+  }
+  const r = restaurants[current];
+  card.innerHTML = `<h3>${r.name}</h3><p>${r.vicinity || ''}</p><p>Rating: ${r.rating}</p>`;
+}
+
+document.getElementById('like').onclick = () => {
+  current++;
+  showRestaurant();
+};
+
+document.getElementById('skip').onclick = () => {
+  current++;
+  showRestaurant();
+};
+
+loadRestaurants();

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,18 @@
+# Server
+
+Simple Express server that queries Google Places to return top three restaurants for a given cuisine and radius.
+
+## Usage
+
+1. Install dependencies with `npm install`.
+2. Create a `.env` file containing your `GOOGLE_PLACES_KEY`.
+3. Start the server using `node index.js`.
+
+The API endpoint `/restaurants` expects `lat`, `lng`, `radius`, and optional `cuisine` query parameters.
+
+### Additional Endpoints
+
+- `POST /friends/add` — Add two users as friends. Body should contain `userId` and `friendId`.
+- `GET /friends/:userId` — Retrieve a user's friend list.
+- `POST /sessions` — Create a new swiping session. Body includes `host`, optional `participants`, `lat`, `lng`, and cuisine info. Returns a session ID and top restaurants.
+- `POST /sessions/:id/swipe` — Record a user's swipe. Responds with `{ match: true }` when everyone likes the same restaurant.

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,114 @@
+import express from 'express';
+import axios from 'axios';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const app = express();
+app.use(express.json());
+const PORT = process.env.PORT || 3000;
+const GOOGLE_KEY = process.env.GOOGLE_PLACES_KEY;
+
+// simple in-memory store for friends and sessions
+const users = {}; // userId -> Set of friendIds
+const sessions = {}; // sessionId -> { users: [], restaurants: [], swipes: {} }
+let sessionCounter = 1;
+
+async function fetchTopRestaurants({ lat, lng, radius = 5000, cuisine = '' }) {
+  const url = 'https://maps.googleapis.com/maps/api/place/nearbysearch/json';
+  const params = {
+    key: GOOGLE_KEY,
+    location: `${lat},${lng}`,
+    radius,
+    type: 'restaurant',
+    keyword: cuisine
+  };
+  const { data } = await axios.get(url, { params });
+  return (data.results || [])
+    .filter(r => r.rating)
+    .sort((a, b) => b.rating - a.rating)
+    .slice(0, 3);
+}
+
+// Basic endpoint to fetch top 3 restaurants for a cuisine within radius
+app.get('/restaurants', async (req, res) => {
+  const { lat, lng, radius = 5000, cuisine = '' } = req.query;
+  if (!GOOGLE_KEY || !lat || !lng) {
+    return res.status(400).json({ error: 'Missing parameters or API key' });
+  }
+
+  try {
+    const url = 'https://maps.googleapis.com/maps/api/place/nearbysearch/json';
+    const params = {
+      key: GOOGLE_KEY,
+      location: `${lat},${lng}`,
+      radius,
+      type: 'restaurant',
+      keyword: cuisine
+    };
+    const { data } = await axios.get(url, { params });
+    const sorted = (data.results || [])
+      .filter(r => r.rating)
+      .sort((a, b) => b.rating - a.rating)
+      .slice(0, 3);
+
+    res.json(sorted);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch places' });
+  }
+});
+
+// ----- Friends -----
+app.post('/friends/add', (req, res) => {
+  const { userId, friendId } = req.body;
+  if (!userId || !friendId) {
+    return res.status(400).json({ error: 'Missing userId or friendId' });
+  }
+  users[userId] = users[userId] || new Set();
+  users[friendId] = users[friendId] || new Set();
+  users[userId].add(friendId);
+  users[friendId].add(userId);
+  res.json({ ok: true });
+});
+
+app.get('/friends/:userId', (req, res) => {
+  const { userId } = req.params;
+  const list = Array.from(users[userId] || []);
+  res.json({ friends: list });
+});
+
+// ----- Sessions -----
+app.post('/sessions', async (req, res) => {
+  const { host, participants = [], lat, lng, radius, cuisine = '' } = req.body;
+  if (!host || !lat || !lng) {
+    return res.status(400).json({ error: 'Missing required fields' });
+  }
+  const id = `s${sessionCounter++}`;
+  const restaurants = await fetchTopRestaurants({ lat, lng, radius, cuisine });
+  sessions[id] = {
+    users: [host, ...participants],
+    restaurants,
+    swipes: {}
+  };
+  res.json({ id, restaurants });
+});
+
+app.post('/sessions/:id/swipe', (req, res) => {
+  const { id } = req.params;
+  const { userId, restaurantId, like } = req.body;
+  const session = sessions[id];
+  if (!session || !userId || !restaurantId) {
+    return res.status(400).json({ error: 'Invalid request' });
+  }
+  session.swipes[userId] = session.swipes[userId] || {};
+  session.swipes[userId][restaurantId] = like;
+
+  // check for match
+  const allLiked = session.users.every(u => session.swipes[u] && session.swipes[u][restaurantId]);
+  const match = allLiked && like;
+  res.json({ match });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "restaurant-tinder-server",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module",
+  "dependencies": {
+    "axios": "^1.6.0",
+    "dotenv": "^16.0.0",
+    "express": "^4.18.0"
+  }
+}


### PR DESCRIPTION
## Summary
- replace placeholder instructions in client README
- describe basic HTML front-end in main README
- add a simple browser client with Like/Skip buttons

## Testing
- `node --version`
- `npm --version`
- `npm install --package-lock-only` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841e379b30c8320801144336ff34b1c